### PR TITLE
Remove the option to disable CORS

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -37,11 +37,17 @@ func NewItem(cacheDir string, req *http.Request) (*Item, error) {
 
 	dir, file := filepath.Split(req.URL.EscapedPath())
 
+	var extra string
 	if req.URL.RawQuery != "" {
 		hasher := sha256.New()
 		hasher.Write([]byte(req.URL.RawQuery))
-		hash := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
-		file += "?" + hash
+		extra = base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+	}
+
+	// TODO: hash the body too
+
+	if extra != "" {
+		file += "?" + extra
 		if len(file) > maxFileNameLength {
 			file = file[:maxFileNameLength]
 		}
@@ -245,6 +251,10 @@ func (w *responseWriter) Write(data []byte) (int, error) {
 }
 
 var selectHeaders = []string{
+	"Access-Control-Allow-Credentials",
+	"Access-Control-Allow-Headers",
+	"Access-Control-Allow-Methods",
+	"Access-Control-Allow-Origin",
 	"Content-Type",
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -22,7 +22,6 @@ type Config struct {
 	Certificate []byte
 	Key         []byte
 	Logger      *slog.Logger
-	Cors        bool
 	Dir         string
 	Hosts       []string
 }
@@ -31,7 +30,6 @@ type Proxy struct {
 	logger      *slog.Logger
 	dir         string
 	hosts       []string
-	cors        bool
 	proxy       *goproxy.ProxyHttpServer
 	downloading sync.Map
 }
@@ -47,7 +45,6 @@ func New(c *Config) (*Proxy, error) {
 		logger: c.Logger,
 		dir:    c.Dir,
 		hosts:  c.Hosts,
-		cors:   c.Cors,
 		proxy:  proxy,
 	}
 
@@ -103,12 +100,9 @@ func (p *Proxy) handleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.R
 		p.logger.Error("failed to generate response from cache item", "error", err, "url", req.URL, "method", req.Method)
 	}
 
-	if p.cors && req.Method != http.MethodOptions {
-		if origin := req.Header.Get("Origin"); origin != "" {
+	if origin := req.Header.Get("Origin"); origin != "" {
+		if allowed := resp.Header.Get("Access-Control-Allow-Origin"); allowed != origin {
 			resp.Header.Set("Access-Control-Allow-Origin", origin)
-		}
-		if a := req.Header.Get("Authorization"); a != "" {
-			resp.Header.Set("Access-Control-Allow-Credentials", "true")
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ type Stash struct {
 	Hosts     []string `help:"Cache responses from these hosts" env:"STASH_HOSTS"`
 	CertFile  string   `help:"Path to CA certificate file" type:"existingfile" required:"" env:"STASH_CERT_FILE"`
 	KeyFile   string   `help:"Path to CA private key file" type:"existingfile" required:"" env:"STASH_KEY_FILE"`
-	Cors      bool     `help:"Include CORS support (on by default)." default:"true" negatable:""`
 	LogLevel  string   `help:"Log level" enum:"debug,info,warn,error" default:"info" env:"STASH_LOG_LEVEL"`
 	LogFormat string   `help:"Log format" enum:"text,json" default:"text" env:"STASH_LOG_FORMAT"`
 }
@@ -57,7 +56,6 @@ func (s *Stash) Run() error {
 		Certificate: certificate,
 		Key:         key,
 		Logger:      logger,
-		Cors:        s.Cors,
 		Dir:         s.Dir,
 		Hosts:       s.Hosts,
 	})

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,6 @@ Flags:
       --hosts=HOSTS,...      Cache responses from these hosts ($STASH_HOSTS)
       --cert-file=STRING     Path to CA certificate file ($STASH_CERT_FILE)
       --key-file=STRING      Path to CA private key file ($STASH_KEY_FILE)
-      --[no-]cors            Include CORS support (on by default).
       --log-level="info"     Log level ($STASH_LOG_LEVEL)
       --log-format="text"    Log format ($STASH_LOG_FORMAT)
 ```


### PR DESCRIPTION
Instead of providing a `--no-cors` option, adapt CORS headers as needed (for changing origin).